### PR TITLE
fix: Headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ app.use("/api/auth/**", async (c) => {
   }
 
   c.header("Access-Control-Allow-Credentials", "true");
+  c.header("Access-Control-Allow-Headers", "Content-Type, Authorization, x-datadog-origin");
 
   // Handle preflight request
   if (c.req.method === "OPTIONS") {


### PR DESCRIPTION
This pull request includes a small change to the `src/index.ts` file. The change adds a new header to the list of allowed headers in the API authentication route.

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R33): Added "x-datadog-origin" to the `Access-Control-Allow-Headers` list in the API authentication route.